### PR TITLE
fix: make trans parser updated to current example netlist file

### DIFF
--- a/MAKE/PLACE_ROUTE/csyn_fp/src/beol_data.cpp
+++ b/MAKE/PLACE_ROUTE/csyn_fp/src/beol_data.cpp
@@ -99,11 +99,11 @@ Transistor::Transistor(const std::vector<std::string>& tokens) {
 	}
 */
 	for (auto iter = tokens.begin() + 6; iter != tokens.end(); ++iter) {
-		if (iter->substr(0, 2) == "W=") {
+		if (iter->substr(0, 2) == "w=") {
 			//std::cout << "Width" << std::endl;
 			width = stod(iter->substr(2, iter->size() - 1));
 		}
-		else if (iter->substr(0, 2) == "L=") {
+		else if (iter->substr(0, 2) == "l=") {
 			//std::cout << "Length" << std::endl;
 			length = stod(iter->substr(2, iter->size() - 1));
 		}


### PR DESCRIPTION
Hi. I noticed that there seemed to be a typo in the transistor parsing codes, which leads to the failure of parsing width and length of a cell. So I made a small change to let it consistent with the current example netlist file.